### PR TITLE
fix: Fix integer refocusing bug and float-to-int parsing logic

### DIFF
--- a/src/structui/file_picker.py
+++ b/src/structui/file_picker.py
@@ -61,8 +61,8 @@ class LocalFilePicker(ui.dialog):
         elif self.allowed_extensions:
             allowed_exts = [ext.lower() if ext.startswith('.') else f'.{ext.lower()}' for ext in self.allowed_extensions]
             paths = [p for p in paths if p.is_dir() or p.suffix.lower() in allowed_exts]
-        paths.sort(key=lambda p: p.name.lower())
 
+        paths.sort(key=lambda p: p.name.lower())
         paths.sort(key=lambda p: not p.is_dir())
 
         self.grid.options['rowData'] = [

--- a/src/structui/ui.py
+++ b/src/structui/ui.py
@@ -162,7 +162,8 @@ class StructUI:
         if opt_type == 'dict_key':
             if isinstance(data_node, dict):
                 k = option.get('key')
-                meta_type = self.schema_manager.get_meta(str(k)).get('type')
+                schema_key = self.schema_manager.get_schema_key_for_path(f"{path}/{k}", self.state.config_data)
+                meta_type = self.schema_manager.get_meta(schema_key).get('type')
                 if meta_type == 'list':
                     data_node[k] = []
                 elif meta_type in ['container', 'dict']:
@@ -282,17 +283,30 @@ class StructUI:
             props_container = ui.column().classes('w-full gap-4')
             
             def render_primitive_input(k, v, parent_node):
-                meta = self.schema_manager.get_meta(str(k))
+                schema_key = self.schema_manager.get_schema_key_for_path(f"{self.selected_path['value']}/{k}", self.state.config_data)
+                meta = self.schema_manager.get_meta(schema_key)
 
-                def make_on_change(prop_key=k, prop_type=meta.get('type')):
+                def make_on_change(prop_key=k, prop_type=meta.get('type'), orig_val=v):
                     def handler(e):
-                        val = e.value
+                        val = getattr(e, 'value', getattr(getattr(e, 'sender', None), 'value', None))
                         if prop_type == 'integer' and val is not None and val != '':
                             try: val = int(float(val))
                             except ValueError: pass
                         elif prop_type in ['number', 'float'] and val is not None and val != '':
-                            try: val = float(val)
+                            try:
+                                if '.' in str(val):
+                                    val = float(val)
+                                else:
+                                    val = int(val)
                             except ValueError: pass
+                        elif not prop_type and val is not None and val != '':
+                            if isinstance(orig_val, int) and type(orig_val) is not bool:
+                                try:
+                                    if '.' in str(val):
+                                        val = float(val)
+                                    else:
+                                        val = int(val)
+                                except ValueError: pass
 
                         self.state.set_data_by_path(self.selected_path["value"], str(prop_key), val)
                         self.state.commit()
@@ -322,7 +336,7 @@ class StructUI:
                         inp = ui.input(label=label_text, value=str(v)).classes('flex-grow').on_value_change(make_on_change())
                         ui.button(icon='folder_open', on_click=pick_file).props('flat round size=sm').tooltip('Select File')
                     elif isinstance(v, float) or (isinstance(v, int) and type(v) is not bool and meta.get('type') != 'integer'):
-                        inp = ui.number(label=label_text, value=v).classes('flex-grow').on_value_change(make_on_change())
+                        inp = ui.input(label=label_text, value=str(v)).classes('flex-grow').props('type="number"').on('blur', make_on_change())
                     elif isinstance(v, int) and type(v) is not bool:
                         # For integers, we add a Dec/Hex toggle switch
                         with ui.row().classes('flex-grow items-center gap-2 flex-nowrap'):
@@ -335,10 +349,17 @@ class StructUI:
                             hex_toggle = ui.switch('Hex', value=is_hex).on_value_change(toggle_hex)
 
                             if is_hex:
-                                hex_val = hex(v) if isinstance(v, int) else ""
+                                hex_val = hex(v) if isinstance(v, int) else v
                                 def on_hex_change(e, pk=k):
                                     try:
-                                        new_val = int(e.value, 16) if e.value else 0
+                                        val = getattr(e, 'value', getattr(getattr(e, 'sender', None), 'value', None))
+                                        raw_val = val.strip() if hasattr(val, 'strip') else val
+                                        if isinstance(raw_val, str) and raw_val.startswith('0x'):
+                                            new_val = int(raw_val, 16)
+                                        elif isinstance(raw_val, str) and raw_val:
+                                            new_val = int(raw_val, 16)
+                                        else:
+                                            new_val = 0
                                         self.state.set_data_by_path(self.selected_path["value"], str(pk), new_val)
                                         self.state.commit()
                                         self.update_save_btn_state()
@@ -346,7 +367,7 @@ class StructUI:
                                         pass
                                 inp = ui.input(label=label_text, value=hex_val).classes('flex-grow').on_value_change(on_hex_change)
                             else:
-                                inp = ui.number(label=label_text, value=v).classes('flex-grow').on_value_change(make_on_change())
+                                inp = ui.input(label=label_text, value=str(v)).classes('flex-grow').props('type="number"').on('blur', make_on_change())
                     else:
                         inp = ui.input(label=label_text, value=str(v)).classes('flex-grow').on_value_change(make_on_change())
                         

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -346,28 +346,18 @@ def test_ui_more_coverage(mock_app_state, mock_schema_manager):
 
     # Coverage for delete current container (line 267)
     parent_list = [{"a": 1}]
-    def side_effect(p):
-        if p == "root": return parent_list
-        if p == "root/0": return parent_list[0]
-        return {}
-    mock_app_state.get_data_by_path.side_effect = side_effect
+    mock_app_state.get_data_by_path.side_effect = lambda p: parent_list if p == "root" else parent_list[0]
     ui_inst.selected_path = {"value": "root/0"}
     
     with patch('structui.ui.ui.row'), patch('structui.ui.ui.button') as mock_btn:
-        del_cb = []
+        del_cb = None
         def mock_btn_side( *args, **kwargs):
-            if kwargs.get('icon') == 'delete':
-                if 'on_click' in kwargs:
-                    del_cb.append(kwargs['on_click'])
-            mock_button = MagicMock()
-            return mock_button
-
+            nonlocal del_cb
+            if kwargs.get('icon') == 'delete': del_cb = kwargs.get('on_click')
+            return MagicMock()
         mock_btn.side_effect = mock_btn_side
         ui_inst.draw_editor("root/0")
-
-        if del_cb:
-            del_cb[-1]()
-
+        if del_cb: del_cb()
         assert len(parent_list) == 0
 
 def test_delete_prop_in_list(mock_app_state, mock_schema_manager):

--- a/tests/test_ui_extra.py
+++ b/tests/test_ui_extra.py
@@ -144,3 +144,42 @@ def test_ui_render_more_coverage(mock_app_state, mock_schema_manager):
                 # Call render
                 ui_inst.render()
                 assert mock_ui_module.page_title.call_count >= 0
+
+
+def test_number_input_parsing(mock_app_state, mock_schema_manager):
+    from structui.ui import StructUI
+    ui_inst = StructUI(mock_app_state, mock_schema_manager)
+    ui_inst.editor_scroll_area = MagicMock()
+    ui_inst.footer_pane = MagicMock()
+    ui_inst.selected_path = {"value": "root"}
+    mock_app_state.get_data_by_path.return_value = {"num_prop": 3, "float_prop": 3.0}
+    mock_schema_manager.get_schema_key_for_path.return_value = "num_prop"
+    mock_schema_manager.get_meta.return_value = {"type": "number"}
+
+    with patch('structui.ui.ui.row'), patch('structui.ui.ui.column') as mock_col,          patch('structui.ui.ui.input') as mock_input,          patch('structui.ui.ui.label'), patch('structui.ui.ui.icon'),          patch('structui.ui.ui.button'):
+        mock_input_inst = MagicMock()
+        mock_input.return_value = mock_input_inst
+        mock_input_inst.classes.return_value = mock_input_inst
+        mock_input_inst.props.return_value = mock_input_inst
+        mock_input_inst.on.return_value = mock_input_inst
+
+        ui_inst.draw_editor("root")
+
+        assert mock_input_inst.on.call_count > 0
+        call_args = mock_input_inst.on.call_args_list[0][0]
+        assert call_args[0] == "blur"
+        handler = call_args[1]
+
+        class MockSender:
+            def __init__(self, val):
+                self.value = val
+
+        class MockEvent:
+            def __init__(self, val):
+                self.sender = MockSender(val)
+
+        handler(MockEvent("4"))
+        mock_app_state.set_data_by_path.assert_called_with("root", "num_prop", 4)
+
+        handler(MockEvent("4.5"))
+        mock_app_state.set_data_by_path.assert_called_with("root", "num_prop", 4.5)


### PR DESCRIPTION
This PR resolves Issue #16 and Issue #17 related to UI data parsing and field defocusing:

1. **Issue #17:** Fixed integer fields losing focus midway through typing by binding to native `.on('blur', ...)` events with standard `ui.input` instead of NiceGUI's default reactive `ui.number` behavior.
2. **Issue #16:** Improved configuration input parsing logic to accurately distinguish between ints and floats based on the presence of a decimal (e.g., inputting `3` maps to `int`, while `3.0` maps to `float`).
3. Refactored NiceGUI event attribute fetching safely across different event types.
4. Cleaned up and updated `pytest` suites to assert correct behavior.

---
*PR created automatically by Jules for task [8522742165766626823](https://jules.google.com/task/8522742165766626823) started by @MoSaeedHammad*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric input value extraction with more defensive handling across event types
  * Enhanced hex mode parsing with whitespace stripping and 0x prefix support; fallback to 0 on parse errors

* **Changes**
  * Updated floating-point number editing to commit changes on blur rather than in real-time
  * Improved schema inference when adding new dictionary keys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->