### PR TITLE
docs and tests: Add index.md and complex scenario testing fixtures

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# StructUI
+
+StructUI is a format-agnostic, schema-driven, hierarchical configuration UI engine built in Python. Designed as a flexible architectural backbone, it parses standard configuration files (YAML, JSON, CSV, XML) and dynamically generates a live web-based property editor based on constraints and metadata defined in a schema file.
+
+The architecture is explicitly decoupled, making it readily extensible to strict domain-specific specifications (e.g., AUTOSAR configurators) and agent-driven programmatic workflows.
+
+## Features
+
+- **Format-Agnostic Parsers:** cleanly separate UI generation from underlying data formats. Out-of-the-box support for YAML, JSON, and XML (including schema-driven arrays and attributes), with abstract base classes extensible to CSV and others.
+- **Hierarchical UI:** Dynamic tree-based rendering with full support for multidimensional containers, dynamic polymorphic list additions, and node mapping. Powered natively by NiceGUI.
+- **Data Validity:** Enforces schema metadata strictly at the UI layer. Missing fields gracefully populate via defaults, required flags trigger locking, and nested typings are continuously evaluated.
+- **Extensibility & Programmatic Control:** Decomposed core logic (App, Parser, State, Schema, UI) allowing external tools and wrappers (e.g. CLI, Agent Workflows) to invoke the editor or inject properties safely.
+- **Hex/Decimal Toggling:** Automatically detects and preserves hex formatting loaded from YAML configurations. Supports inline format toggling between hex and decimal, with validation logic to restrict inputs to valid hex formats and enforce platform/64-bit size limits.
+
+## Table of Contents
+
+- [Roadmap](ROADMAP.md)

--- a/tests/fixtures/complex_schema.yaml
+++ b/tests/fixtures/complex_schema.yaml
@@ -1,0 +1,29 @@
+root:
+  type: dict
+  allowed_children: [network, diagnostics]
+network:
+  type: dict
+  allowed_children: [ecu_list]
+ecu_list:
+  type: list
+  list_item_type: ecu
+ecu:
+  type: dict
+  allowed_children: [id, active, timeout]
+  required: true
+id:
+  type: string
+  required: true
+active:
+  type: boolean
+timeout:
+  type: number
+diagnostics:
+  type: dict
+  allowed_children: [mode, errors]
+mode:
+  type: string
+  options: [normal, extended, programming]
+errors:
+  type: list
+  list_item_type: string

--- a/tests/fixtures/polymorphic_list.yaml
+++ b/tests/fixtures/polymorphic_list.yaml
@@ -1,0 +1,31 @@
+root:
+  type: dict
+  allowed_children: [vehicles]
+vehicles:
+  type: list
+  list_item_types: [car, truck, motorcycle]
+car:
+  type: dict
+  allowed_children: [make, model, doors]
+  label_key: make
+truck:
+  type: dict
+  allowed_children: [make, payload, is_electric]
+  label_key: make
+motorcycle:
+  type: dict
+  allowed_children: [make, cc]
+  label_key: make
+make:
+  type: string
+  required: true
+model:
+  type: string
+doors:
+  type: integer
+payload:
+  type: number
+is_electric:
+  type: boolean
+cc:
+  type: integer

--- a/tests/fixtures/strict_types.yaml
+++ b/tests/fixtures/strict_types.yaml
@@ -1,0 +1,23 @@
+root:
+  type: dict
+  allowed_children: [my_bool, my_int, my_float, my_string, my_enum, my_path, my_hex]
+my_bool:
+  type: boolean
+  required: true
+my_int:
+  type: integer
+  required: true
+my_float:
+  type: float
+  required: true
+my_string:
+  type: string
+  required: true
+my_enum:
+  type: string
+  options: [opt1, opt2, opt3]
+my_path:
+  type: path
+  extensions: [.txt, .md]
+my_hex:
+  type: number

--- a/tests/test_fixtures_scenarios.py
+++ b/tests/test_fixtures_scenarios.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import MagicMock
+from structui.schema import SchemaManager
+from structui.state import AppState
+
+def test_complex_schema_integration(tmp_path):
+    schema_manager = SchemaManager("tests/fixtures/complex_schema.yaml")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    app_state = AppState(str(data_dir), schema_manager)
+    app_state.config_data = {
+        "network.yaml": {
+            "ecu_list": [
+                {"id": "ECU_1", "active": True, "timeout": 100},
+                {"id": "ECU_2", "active": False, "timeout": 200}
+            ]
+        },
+        "diagnostics.yaml": {
+            "mode": "normal",
+            "errors": ["E_SYS", "E_NET"]
+        }
+    }
+
+    # Test valid retrieval
+    ecu_node = app_state.get_data_by_path("root/network.yaml/ecu_list/0")
+    assert ecu_node["id"] == "ECU_1"
+
+    # Test schema metadata for deeply nested node
+    schema_key = schema_manager.get_schema_key_for_path("root/network.yaml/ecu_list/0", app_state.config_data)
+    assert schema_key == "ecu"
+    meta = schema_manager.get_meta(schema_key)
+    assert "id" in meta.get("allowed_children")
+
+def test_polymorphic_list_integration(tmp_path):
+    schema_manager = SchemaManager("tests/fixtures/polymorphic_list.yaml")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    app_state = AppState(str(data_dir), schema_manager)
+    app_state.config_data = {
+        "vehicles.yaml": [
+            {"make": "Ford", "model": "Mustang", "doors": 2},
+            {"make": "Volvo", "payload": 15000, "is_electric": True},
+            {"make": "Honda", "cc": 600}
+        ]
+    }
+
+    # Check type resolution of list items based on available properties
+    # Car
+    car_key = schema_manager.get_schema_key_for_path("root/vehicles.yaml/0", app_state.config_data)
+    assert car_key == "car"
+
+    # Truck
+    truck_key = schema_manager.get_schema_key_for_path("root/vehicles.yaml/1", app_state.config_data)
+    assert truck_key == "truck"
+
+    # Motorcycle
+    moto_key = schema_manager.get_schema_key_for_path("root/vehicles.yaml/2", app_state.config_data)
+    assert moto_key == "motorcycle"
+
+def test_strict_types_integration(tmp_path):
+    schema_manager = SchemaManager("tests/fixtures/strict_types.yaml")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    app_state = AppState(str(data_dir), schema_manager)
+    app_state.config_data = {
+        "config.yaml": {
+            "my_bool": True,
+            "my_int": 42,
+            "my_float": 3.14,
+            "my_string": "test",
+            "my_enum": "opt1"
+        }
+    }
+
+    # Test updating values
+    app_state.set_data_by_path("root/config.yaml", "my_int", 100)
+    assert app_state.get_data_by_path("root/config.yaml/my_int") == 100
+
+    app_state.set_data_by_path("root/config.yaml", "my_bool", False)
+    assert app_state.get_data_by_path("root/config.yaml/my_bool") == False


### PR DESCRIPTION
Adds standard documentation entry point (`docs/index.md`) and introduces several complex YAML schemas to `tests/fixtures/` along with a brand new `tests/test_fixtures_scenarios.py` to test StructUI's `AppState` capability in deeper, more edge-case oriented real-world scenarios. All actions complete the user request to include more complete testing scenarios and sync up the codebase docs.

---
*PR created automatically by Jules for task [4265042508244998982](https://jules.google.com/task/4265042508244998982) started by @MoSaeedHammad*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new landing page introducing StructUI and its main capabilities, with a link to the roadmap.

* **Tests**
  * Added broader integration coverage for complex nested configurations, polymorphic list items, and strict typed values.
  * Added new test fixtures for hierarchical schemas and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->